### PR TITLE
Ignore READMEs and docs during CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # gopayroll
 A demo payroll system written in Go.
+
+## Github Actions
+This repository uses [Github Actions](https://github.com/features/actions) as its CI/CD workflow.
+
+## Dockerhub
+On push to the `master` branch, this repository will build and push changed images to the [Dockerhub registry](https://hub.docker.com/_/registry)
+
+If you clone this repository and wish to also push your images to the Dockerhub registry, you will need to ensure the following environment variables are set:
+
+- DOCKER_REGISTRY
+  - the Dockerhub repository
+- DOCKER_ACCESS_TOKEN
+  - the Dockerhub access token
+- DOCKER_ACCESS_USER
+  - the Dockerhub user with permission to push to the repository
+
+Using Github Actions, you can add this variables as [Secrets](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).

--- a/ci/find_dirty_pkgs.py
+++ b/ci/find_dirty_pkgs.py
@@ -26,7 +26,7 @@ from typing import Tuple
 logger = logging.getLogger(__name__)
 
 # Dirty files matching these regex patterns will be ignored
-ignore_file_patterns = [
+ignore_dirty_file_patterns = [
     re.compile(r'.*README$'),        # README
     re.compile(r'.*\.md$'),          # Markdown
     re.compile(r'.*/docs/.+')        # files in a /docs subfolder
@@ -53,7 +53,7 @@ def load_dirty_dirs(github_home: str) -> set:
     dirty_dirs = set()
     with open(files_json_path) as f:
         for dirty_file in json.load(f):
-            if ignore_file(dirty_file):
+            if ignore_dirty_file(dirty_file):
                 logger.debug(f'Ignoring dirty file {dirty_file}')
                 continue
 
@@ -68,6 +68,13 @@ def load_dirty_dirs(github_home: str) -> set:
             dirty_dirs.add(dirname)
 
     return dirty_dirs
+
+
+def ignore_dirty_file(file_path: str) -> bool:
+    for p in ignore_dirty_file_patterns:
+        if p.match(file_path):
+            return True
+    return False
 
 
 def find_dirty_import_paths(dirty_dirs: set) -> set:
@@ -182,13 +189,6 @@ def run_cmd_with_output(*args: str) -> Tuple[int, str, str]:
     stdout, stderr = process.communicate()
 
     return process.returncode, stdout, stderr
-
-
-def ignore_file(file_path: str) -> bool:
-    for p in ignore_file_patterns:
-        if p.match(file_path):
-            return True
-    return False
 
 
 if __name__ == '__main__':

--- a/ci/static_check_pkg.sh
+++ b/ci/static_check_pkg.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# This script will execute standard Go formatting and security static checks
+# on the given package.
+
 # ------------------------
 #  Dependencies
 # ------------------------
@@ -21,6 +24,9 @@ FLAGS=$2
 IGNORE_DEFER_ERR=${3:-false}
 REPORT_COMMENT=${4:-true}
 
+# ------------------------
+#  Global Variables
+# ------------------------
 COMMENT=""
 SUCCESS=0
 

--- a/heustics/src/services/helloworld/README.md
+++ b/heustics/src/services/helloworld/README.md
@@ -1,0 +1,9 @@
+# helloworld
+A dummy `Hello World` service.
+
+| System Characteristic | Description |
+|--------------------|------------|
+| SLO (Availability) | 99.99% |
+| SLO (Latency Median) | 300 ms |
+| SLO (Latency 95th) | 500 ms |
+| Docker Registery | [heusticalgos/gopayroll-helloworld](https://hub.docker.com/r/heusticalgos/gopayroll-helloworld) |

--- a/heustics/src/services/helloworld/README.md
+++ b/heustics/src/services/helloworld/README.md
@@ -3,7 +3,4 @@ A dummy `Hello World` service.
 
 | System Characteristic | Description |
 |--------------------|------------|
-| SLO (Availability) | 99.99% |
-| SLO (Latency Median) | 300 ms |
-| SLO (Latency 95th) | 500 ms |
 | Docker Registery | [heusticalgos/gopayroll-helloworld](https://hub.docker.com/r/heusticalgos/gopayroll-helloworld) |

--- a/heustics/src/services/payroll/README.md
+++ b/heustics/src/services/payroll/README.md
@@ -1,0 +1,19 @@
+
+# payroll service
+
+This service manages payroll requests.
+
+| System Characteristic | Description |
+|--------------------|------------|
+| SLO (Availability) | 99.99% |
+| SLO (Latency Median) | 300 ms |
+| SLO (Latency 95th) | 500 ms |
+| Docker Registery | [heusticalgos/gopayroll-payroll](https://hub.docker.com/r/heusticalgos/gopayroll-payroll) |
+
+## Business Overview
+
+TODO
+
+## Technical Overview
+
+TODO


### PR DESCRIPTION
When the CI process looks for dirty packages, add rule to ignore READMEs, Markdown files, and any changes in a /docs subfolder.

This PR also:
1. Adds skeleton READMEs for the helloworld and payroll service
2. Updates CI script doc strings and comments

- CI-IGNORE_readmes_and_docs